### PR TITLE
Rename package `diary` to `home`

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -14,7 +14,7 @@
         android:supportsRtl="true"
         android:theme="@style/WeatherDiaryTheme">
 
-        <activity android:name=".presentation.diary.DiaryActivity">
+        <activity android:name=".presentation.home.HomeActivity">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/app/src/main/java/com/chaeniiz/weatherdiary/presentation/home/HomeActivity.kt
+++ b/app/src/main/java/com/chaeniiz/weatherdiary/presentation/home/HomeActivity.kt
@@ -1,4 +1,4 @@
-package com.chaeniiz.weatherdiary.presentation.diary
+package com.chaeniiz.weatherdiary.presentation.home
 
 import android.content.Intent
 import android.os.Bundle
@@ -8,19 +8,19 @@ import com.chaeniiz.entity.entities.Diary
 import com.chaeniiz.weatherdiary.R
 import com.chaeniiz.weatherdiary.presentation.RequestCode
 import com.chaeniiz.weatherdiary.presentation.write.WriteActivity
-import kotlinx.android.synthetic.main.activity_diary.*
+import kotlinx.android.synthetic.main.activity_home.*
 import org.jetbrains.anko.onClick
 import org.jetbrains.anko.toast
 
-class DiaryActivity : AppCompatActivity(), DiaryView {
+class HomeActivity : AppCompatActivity(), HomeView {
 
-    private val presenter: DiaryPresenter by lazy {
-        DiaryPresenter(this, this)
+    private val presenter: HomePresenter by lazy {
+        HomePresenter(this, this)
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContentView(R.layout.activity_diary)
+        setContentView(R.layout.activity_home)
 
         writeButton.onClick {
             presenter.onWriteButtonClicked()
@@ -40,7 +40,7 @@ class DiaryActivity : AppCompatActivity(), DiaryView {
 
     override fun setAdapter(diaries: List<Diary>) {
         with(diaryRecyclerView) {
-            adapter = DiaryRecyclerAdapter(
+            adapter = HomeRecyclerAdapter(
                 diaries,
                 presenter::onDiaryClicked
             )

--- a/app/src/main/java/com/chaeniiz/weatherdiary/presentation/home/HomePresenter.kt
+++ b/app/src/main/java/com/chaeniiz/weatherdiary/presentation/home/HomePresenter.kt
@@ -1,4 +1,4 @@
-package com.chaeniiz.weatherdiary.presentation.diary
+package com.chaeniiz.weatherdiary.presentation.home
 
 import android.content.Context
 import com.chaeniiz.entity.entities.Diary
@@ -6,8 +6,8 @@ import com.chaeniiz.weatherdiary.data.local.DiaryRepository
 import com.chaeniiz.weatherdiary.presentation.base.DefaultSingleObserver
 import usecases.GetDiaries
 
-class DiaryPresenter(
-    val view: DiaryView,
+class HomePresenter(
+    val view: HomeView,
     context: Context,
     private val getDiaries: GetDiaries = GetDiaries(DiaryRepository(context))
 ) {

--- a/app/src/main/java/com/chaeniiz/weatherdiary/presentation/home/HomeRecyclerAdapter.kt
+++ b/app/src/main/java/com/chaeniiz/weatherdiary/presentation/home/HomeRecyclerAdapter.kt
@@ -1,4 +1,4 @@
-package com.chaeniiz.weatherdiary.presentation.diary
+package com.chaeniiz.weatherdiary.presentation.home
 
 import android.view.LayoutInflater
 import android.view.ViewGroup
@@ -7,15 +7,15 @@ import com.chaeniiz.entity.entities.Diary
 import com.chaeniiz.weatherdiary.R
 import org.jetbrains.anko.onClick
 
-class DiaryRecyclerAdapter(
+class HomeRecyclerAdapter(
     private val diaries: List<Diary>,
     private val onItemClicked: (id: Int) -> Unit
-) : RecyclerView.Adapter<DiaryViewHolder>() {
+) : RecyclerView.Adapter<HomeViewHolder>() {
 
     override fun getItemCount(): Int = diaries.size
 
-    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): DiaryViewHolder =
-        DiaryViewHolder(
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): HomeViewHolder =
+        HomeViewHolder(
             LayoutInflater.from(parent.context).inflate(R.layout.item_diary, parent, false)
         ).apply {
             itemView.onClick {
@@ -23,7 +23,7 @@ class DiaryRecyclerAdapter(
             }
         }
 
-    override fun onBindViewHolder(holder: DiaryViewHolder, position: Int) {
+    override fun onBindViewHolder(holder: HomeViewHolder, position: Int) {
         holder.bind(diaries[position])
     }
 }

--- a/app/src/main/java/com/chaeniiz/weatherdiary/presentation/home/HomeView.kt
+++ b/app/src/main/java/com/chaeniiz/weatherdiary/presentation/home/HomeView.kt
@@ -1,8 +1,8 @@
-package com.chaeniiz.weatherdiary.presentation.diary
+package com.chaeniiz.weatherdiary.presentation.home
 
 import com.chaeniiz.entity.entities.Diary
 
-interface DiaryView {
+interface HomeView {
     fun startWriteActivity()
     fun setAdapter(diaries: List<Diary>)
     fun showToast(text: String)

--- a/app/src/main/java/com/chaeniiz/weatherdiary/presentation/home/HomeViewHolder.kt
+++ b/app/src/main/java/com/chaeniiz/weatherdiary/presentation/home/HomeViewHolder.kt
@@ -1,4 +1,4 @@
-package com.chaeniiz.weatherdiary.presentation.diary
+package com.chaeniiz.weatherdiary.presentation.home
 
 import android.view.View
 import androidx.recyclerview.widget.RecyclerView
@@ -7,7 +7,7 @@ import com.chaeniiz.weatherdiary.presentation.includeCommaAndSpace
 import com.chaeniiz.weatherdiary.presentation.toFormattedString
 import kotlinx.android.synthetic.main.item_diary.view.*
 
-class DiaryViewHolder(view: View) : RecyclerView.ViewHolder(view) {
+class HomeViewHolder(view: View) : RecyclerView.ViewHolder(view) {
     fun bind(diary: Diary) {
         with(itemView) {
             dateTextView.text = diary.updatedAt.toFormattedString("yyyy. MM. dd")

--- a/app/src/main/res/layout/activity_home.xml
+++ b/app/src/main/res/layout/activity_home.xml
@@ -5,7 +5,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    tools:context=".presentation.diary.DiaryActivity">
+    tools:context=".presentation.home.HomeActivity">
 
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/diaryRecyclerView"


### PR DESCRIPTION
개별 일기 패키지명을 `diary`로 가져가기 위하여 기존 일기 리스트를 표시하던 `diary` 패키지명을 `home`으로 변경합니다.