### PR TITLE
Add diary content view

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -22,6 +22,7 @@
             </intent-filter>
         </activity>
         <activity android:name=".presentation.write.WriteActivity" />
+        <activity android:name=".presentation.diary.DiaryActivity" />
 
     </application>
 

--- a/app/src/main/java/com/chaeniiz/weatherdiary/data/local/DiaryDao.kt
+++ b/app/src/main/java/com/chaeniiz/weatherdiary/data/local/DiaryDao.kt
@@ -2,6 +2,7 @@ package com.chaeniiz.weatherdiary.data.local
 
 import androidx.room.*
 import com.chaeniiz.weatherdiary.data.local.model.Diary
+import java.util.*
 
 @Dao
 interface DiaryDao {
@@ -14,8 +15,8 @@ interface DiaryDao {
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     fun insertDiary(diary: Diary)
 
-    @Update
-    fun updateDiary(diary: Diary)
+    @Query("UPDATE diary SET location = :location, weather = :weather, content = :content, updated_at = :updatedAt WHERE id = :id")
+    fun updateDiary(id: Int, location: String, weather: String, content: String, updatedAt: Date)
 
     @Delete
     fun deleteDiary(diary: Diary)

--- a/app/src/main/java/com/chaeniiz/weatherdiary/data/local/DiaryDao.kt
+++ b/app/src/main/java/com/chaeniiz/weatherdiary/data/local/DiaryDao.kt
@@ -1,6 +1,9 @@
 package com.chaeniiz.weatherdiary.data.local
 
-import androidx.room.*
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
 import com.chaeniiz.weatherdiary.data.local.model.Diary
 import java.util.*
 
@@ -18,6 +21,6 @@ interface DiaryDao {
     @Query("UPDATE diary SET location = :location, weather = :weather, content = :content, updated_at = :updatedAt WHERE id = :id")
     fun updateDiary(id: Int, location: String, weather: String, content: String, updatedAt: Date)
 
-    @Delete
-    fun deleteDiary(diary: Diary)
+    @Query("DELETE FROM diary WHERE id = :id")
+    fun deleteDiary(id: Int)
 }

--- a/app/src/main/java/com/chaeniiz/weatherdiary/data/local/DiaryRepository.kt
+++ b/app/src/main/java/com/chaeniiz/weatherdiary/data/local/DiaryRepository.kt
@@ -31,7 +31,13 @@ class DiaryRepository(context: Context) : DiaryRepository {
 
     override fun updateDiary(diary: Diary): Completable =
         Completable.fromCallable {
-            dao.updateDiary(diary.toLocalModel())
+            dao.updateDiary(
+                diary.id,
+                diary.location,
+                diary.weather,
+                diary.content,
+                diary.updatedAt
+            )
         }
 
     override fun deleteDiary(diary: Diary): Completable =

--- a/app/src/main/java/com/chaeniiz/weatherdiary/data/local/DiaryRepository.kt
+++ b/app/src/main/java/com/chaeniiz/weatherdiary/data/local/DiaryRepository.kt
@@ -40,8 +40,8 @@ class DiaryRepository(context: Context) : DiaryRepository {
             )
         }
 
-    override fun deleteDiary(diary: Diary): Completable =
+    override fun deleteDiary(id: Int): Completable =
         Completable.fromCallable {
-            dao.deleteDiary(diary.toLocalModel())
+            dao.deleteDiary(id)
         }
 }

--- a/app/src/main/java/com/chaeniiz/weatherdiary/presentation/RequestCode.kt
+++ b/app/src/main/java/com/chaeniiz/weatherdiary/presentation/RequestCode.kt
@@ -1,5 +1,6 @@
 package com.chaeniiz.weatherdiary.presentation
 
 enum class RequestCode {
-    WRITE_ACTIVITY_CODE
+    WRITE_ACTIVITY_CODE,
+    DIARY_ACTIVITY_CODE
 }

--- a/app/src/main/java/com/chaeniiz/weatherdiary/presentation/Util.kt
+++ b/app/src/main/java/com/chaeniiz/weatherdiary/presentation/Util.kt
@@ -1,5 +1,6 @@
 package com.chaeniiz.weatherdiary.presentation
 
+import com.chaeniiz.entity.entities.Weather
 import java.text.SimpleDateFormat
 import java.util.*
 
@@ -15,3 +16,14 @@ fun Date.toFormattedString(
 
 fun String.includeCommaAndSpace(): String =
     "$this, "
+
+fun Weather.convertWeather(): String =
+    when (this.id) {
+        in 0..299 -> "뇌우"
+        in 300..399 -> "이슬비"
+        in 400..599 -> "비"
+        in 600..699 -> "눈"
+        in 700..799 -> "안개"
+        800 -> "맑음"
+        else -> "구름 많음"
+    }

--- a/app/src/main/java/com/chaeniiz/weatherdiary/presentation/diary/DiaryActivity.kt
+++ b/app/src/main/java/com/chaeniiz/weatherdiary/presentation/diary/DiaryActivity.kt
@@ -1,12 +1,13 @@
 package com.chaeniiz.weatherdiary.presentation.diary
 
-import android.content.Context
+import android.app.Activity
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.widget.TextView
 import androidx.appcompat.app.AppCompatActivity
 import com.chaeniiz.entity.entities.City
 import com.chaeniiz.weatherdiary.R
+import com.chaeniiz.weatherdiary.presentation.RequestCode
 import com.chaeniiz.weatherdiary.presentation.includeCommaAndSpace
 import kotlinx.android.synthetic.main.activity_diary.*
 import org.jetbrains.anko.*
@@ -16,12 +17,13 @@ class DiaryActivity : AppCompatActivity(), DiaryView {
     companion object {
         const val KEY_DIARY_ID = "diary_id"
 
-        fun start(context: Context, id: Int) {
-            context.run {
-                startActivity(
+        fun startForResult(activity: Activity, id: Int) {
+            with(activity) {
+                startActivityForResult(
                     intentFor<DiaryActivity>(
                         KEY_DIARY_ID to id
-                    )
+                    ),
+                    RequestCode.DIARY_ACTIVITY_CODE.ordinal
                 )
             }
         }
@@ -38,6 +40,12 @@ class DiaryActivity : AppCompatActivity(), DiaryView {
 
         locationTextView.onClick {
             presenter.onLocationEditTextClicked()
+        }
+        editButton.onClick {
+            presenter.onEditButtonClicked(
+                id = intent.getIntExtra(KEY_DIARY_ID, 0),
+                content = contentEditText.text.toString()
+            )
         }
 
         presenter.onCreate(

--- a/app/src/main/java/com/chaeniiz/weatherdiary/presentation/diary/DiaryActivity.kt
+++ b/app/src/main/java/com/chaeniiz/weatherdiary/presentation/diary/DiaryActivity.kt
@@ -1,10 +1,26 @@
 package com.chaeniiz.weatherdiary.presentation.diary
 
+import android.content.Context
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
 import com.chaeniiz.weatherdiary.R
+import org.jetbrains.anko.intentFor
 
 class DiaryActivity : AppCompatActivity(), DiaryView {
+
+    companion object {
+        const val KEY_DIARY_ID = "diary_id"
+
+        fun start(context: Context, id: Int) {
+            context.run {
+                startActivity(
+                    intentFor<DiaryActivity>(
+                        KEY_DIARY_ID to id
+                    )
+                )
+            }
+        }
+    }
 
     private val presenter: DiaryPresenter by lazy {
         DiaryPresenter(this, this)
@@ -14,7 +30,9 @@ class DiaryActivity : AppCompatActivity(), DiaryView {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_diary)
 
-        presenter.onCreate()
+        presenter.onCreate(
+            id = intent.getIntExtra(KEY_DIARY_ID, 0)
+        )
     }
 
     override fun onDestroy() {

--- a/app/src/main/java/com/chaeniiz/weatherdiary/presentation/diary/DiaryActivity.kt
+++ b/app/src/main/java/com/chaeniiz/weatherdiary/presentation/diary/DiaryActivity.kt
@@ -66,6 +66,10 @@ class DiaryActivity : AppCompatActivity(), DiaryView {
         locationTextView.text = text
     }
 
+    override fun setUpdatedAtTextView(updatedAt: String) {
+        updatedAtTextView.text = updatedAt
+    }
+
     override fun setContentTextView(content: String) {
         contentEditText.setText(content)
     }

--- a/app/src/main/java/com/chaeniiz/weatherdiary/presentation/diary/DiaryActivity.kt
+++ b/app/src/main/java/com/chaeniiz/weatherdiary/presentation/diary/DiaryActivity.kt
@@ -47,6 +47,9 @@ class DiaryActivity : AppCompatActivity(), DiaryView {
                 content = contentEditText.text.toString()
             )
         }
+        deleteButton.onClick {
+            presenter.onDeleteButtonClicked()
+        }
 
         presenter.onCreate(
             id = intent.getIntExtra(KEY_DIARY_ID, 0)
@@ -90,6 +93,18 @@ class DiaryActivity : AppCompatActivity(), DiaryView {
             customView(dialogView)
         }
         cityDialog.show()
+    }
+
+    override fun showDeleteConfirmDialog() {
+        AlertDialogBuilder(this).apply {
+            message(getString(R.string.delete_confirm_dialog_message))
+            positiveButton(R.string.general_dialog_delete) {
+                presenter.onDeleteConfirmed(id = intent.getIntExtra(KEY_DIARY_ID, 0))
+            }
+            negativeButton(R.string.general_dialog_cancel) {
+                dismiss()
+            }
+        }.show()
     }
 
     override fun dismissCityDialog() {

--- a/app/src/main/java/com/chaeniiz/weatherdiary/presentation/diary/DiaryActivity.kt
+++ b/app/src/main/java/com/chaeniiz/weatherdiary/presentation/diary/DiaryActivity.kt
@@ -95,6 +95,20 @@ class DiaryActivity : AppCompatActivity(), DiaryView {
         cityDialog.show()
     }
 
+    override fun showErrorDialog(emptyContent: Boolean) {
+        AlertDialogBuilder(this).apply {
+            message(
+                if (emptyContent)
+                    getString(R.string.error_no_content)
+                else
+                    getString(R.string.error_no_location)
+            )
+            positiveButton(getString(R.string.general_dialog_accept)) {
+                dismiss()
+            }
+        }.show()
+    }
+
     override fun showDeleteConfirmDialog() {
         AlertDialogBuilder(this).apply {
             message(getString(R.string.delete_confirm_dialog_message))

--- a/app/src/main/java/com/chaeniiz/weatherdiary/presentation/diary/DiaryActivity.kt
+++ b/app/src/main/java/com/chaeniiz/weatherdiary/presentation/diary/DiaryActivity.kt
@@ -2,9 +2,14 @@ package com.chaeniiz.weatherdiary.presentation.diary
 
 import android.content.Context
 import android.os.Bundle
+import android.view.LayoutInflater
+import android.widget.TextView
 import androidx.appcompat.app.AppCompatActivity
+import com.chaeniiz.entity.entities.City
 import com.chaeniiz.weatherdiary.R
-import org.jetbrains.anko.intentFor
+import com.chaeniiz.weatherdiary.presentation.includeCommaAndSpace
+import kotlinx.android.synthetic.main.activity_diary.*
+import org.jetbrains.anko.*
 
 class DiaryActivity : AppCompatActivity(), DiaryView {
 
@@ -25,10 +30,15 @@ class DiaryActivity : AppCompatActivity(), DiaryView {
     private val presenter: DiaryPresenter by lazy {
         DiaryPresenter(this, this)
     }
+    lateinit var cityDialog: AlertDialogBuilder
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_diary)
+
+        locationTextView.onClick {
+            presenter.onLocationEditTextClicked()
+        }
 
         presenter.onCreate(
             id = intent.getIntExtra(KEY_DIARY_ID, 0)
@@ -38,5 +48,48 @@ class DiaryActivity : AppCompatActivity(), DiaryView {
     override fun onDestroy() {
         super.onDestroy()
         presenter.onDestroy()
+    }
+
+    override fun setLocationTextView(location: String, weather: String) {
+        val text = location.includeCommaAndSpace() + weather
+        locationTextView.text = text
+    }
+
+    override fun setContentTextView(content: String) {
+        contentEditText.setText(content)
+    }
+
+    override fun showCityDialog() {
+        cityDialog = AlertDialogBuilder(this).apply {
+            val dialogView =
+                LayoutInflater.from(this@DiaryActivity).inflate(R.layout.dialog_cities, null)
+            dialogView.find<TextView>(R.id.seoulTextView)
+                .onClick { presenter.onCityClicked(City.SEOUL) }
+            dialogView.find<TextView>(R.id.incheonTextView)
+                .onClick { presenter.onCityClicked(City.INCHEON) }
+            dialogView.find<TextView>(R.id.daejeonTextView)
+                .onClick { presenter.onCityClicked(City.DAEJEON) }
+            dialogView.find<TextView>(R.id.gwangjuTextView)
+                .onClick { presenter.onCityClicked(City.GWANGJU) }
+            dialogView.find<TextView>(R.id.busanTextView)
+                .onClick { presenter.onCityClicked(City.BUSAN) }
+            dialogView.find<TextView>(R.id.daeguTextView)
+                .onClick { presenter.onCityClicked(City.DAEGU) }
+            dialogView.find<TextView>(R.id.ulsanTextView)
+                .onClick { presenter.onCityClicked(City.ULSAN) }
+            dialogView.find<TextView>(R.id.jejuTextView)
+                .onClick { presenter.onCityClicked(City.JEJU) }
+            customView(dialogView)
+        }
+        cityDialog.show()
+    }
+
+    override fun dismissCityDialog() {
+        if (::cityDialog.isInitialized)
+            cityDialog.dismiss()
+    }
+
+    override fun showErrorToast() {
+        toast(R.string.general_error)
     }
 }

--- a/app/src/main/java/com/chaeniiz/weatherdiary/presentation/diary/DiaryActivity.kt
+++ b/app/src/main/java/com/chaeniiz/weatherdiary/presentation/diary/DiaryActivity.kt
@@ -1,0 +1,24 @@
+package com.chaeniiz.weatherdiary.presentation.diary
+
+import android.os.Bundle
+import androidx.appcompat.app.AppCompatActivity
+import com.chaeniiz.weatherdiary.R
+
+class DiaryActivity : AppCompatActivity(), DiaryView {
+
+    private val presenter: DiaryPresenter by lazy {
+        DiaryPresenter(this, this)
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_diary)
+
+        presenter.onCreate()
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        presenter.onDestroy()
+    }
+}

--- a/app/src/main/java/com/chaeniiz/weatherdiary/presentation/diary/DiaryPresenter.kt
+++ b/app/src/main/java/com/chaeniiz/weatherdiary/presentation/diary/DiaryPresenter.kt
@@ -1,17 +1,83 @@
 package com.chaeniiz.weatherdiary.presentation.diary
 
 import android.content.Context
+import com.chaeniiz.entity.entities.City
+import com.chaeniiz.entity.entities.CurrentWeather
+import com.chaeniiz.entity.entities.Diary
+import com.chaeniiz.weatherdiary.data.local.DiaryRepository
+import com.chaeniiz.weatherdiary.data.network.repositories.CurrentWeatherRepository
+import com.chaeniiz.weatherdiary.presentation.base.DefaultSingleObserver
+import com.chaeniiz.weatherdiary.presentation.convertWeather
+import usecases.GetCurrentWeather
+import usecases.GetDiary
 
 class DiaryPresenter(
     val view: DiaryView,
-    context: Context
+    context: Context,
+    private val getDiary: GetDiary = GetDiary(DiaryRepository(context)),
+    private val getCurrentWeather: GetCurrentWeather = GetCurrentWeather(
+        CurrentWeatherRepository(
+            context
+        )
+    )
 ) {
 
-    fun onDestroy() {
+    private var location: String = ""
+    private var weather: String = ""
 
+    fun onDestroy() {
+        getDiary.dispose()
     }
 
     fun onCreate(id: Int) {
+        getDiary(id)
+    }
 
+    fun onLocationEditTextClicked() {
+        view.showCityDialog()
+    }
+
+    fun onCityClicked(city: City) {
+        location = city.formattedString
+        getCurrentWeather(city)
+    }
+
+    private fun getDiary(id: Int) {
+        getDiary.apply {
+            this.id = id
+        }.execute(object : DefaultSingleObserver<Diary>() {
+            override fun onSuccess(t: Diary) {
+                view.setLocationTextView(
+                    location = t.location,
+                    weather = t.weather
+                )
+                view.setContentTextView(t.content)
+            }
+
+            override fun onError(e: Throwable) {
+                super.onError(e)
+                view.showErrorToast()
+            }
+        })
+    }
+
+    private fun getCurrentWeather(city: City) {
+        getCurrentWeather.apply {
+            this.city = city.value
+        }.execute(object : DefaultSingleObserver<CurrentWeather>() {
+            override fun onSuccess(t: CurrentWeather) {
+                weather = t.weather.first().convertWeather()
+                view.setLocationTextView(
+                    location = city.formattedString,
+                    weather = t.weather.first().convertWeather()
+                )
+                view.dismissCityDialog()
+            }
+
+            override fun onError(e: Throwable) {
+                super.onError(e)
+                view.showErrorToast()
+            }
+        })
     }
 }

--- a/app/src/main/java/com/chaeniiz/weatherdiary/presentation/diary/DiaryPresenter.kt
+++ b/app/src/main/java/com/chaeniiz/weatherdiary/presentation/diary/DiaryPresenter.kt
@@ -1,0 +1,17 @@
+package com.chaeniiz.weatherdiary.presentation.diary
+
+import android.content.Context
+
+class DiaryPresenter(
+    val view: DiaryView,
+    context: Context
+) {
+
+    fun onDestroy() {
+
+    }
+
+    fun onCreate() {
+
+    }
+}

--- a/app/src/main/java/com/chaeniiz/weatherdiary/presentation/diary/DiaryPresenter.kt
+++ b/app/src/main/java/com/chaeniiz/weatherdiary/presentation/diary/DiaryPresenter.kt
@@ -11,7 +11,7 @@ class DiaryPresenter(
 
     }
 
-    fun onCreate() {
+    fun onCreate(id: Int) {
 
     }
 }

--- a/app/src/main/java/com/chaeniiz/weatherdiary/presentation/diary/DiaryPresenter.kt
+++ b/app/src/main/java/com/chaeniiz/weatherdiary/presentation/diary/DiaryPresenter.kt
@@ -9,6 +9,7 @@ import com.chaeniiz.weatherdiary.data.network.repositories.CurrentWeatherReposit
 import com.chaeniiz.weatherdiary.presentation.base.DefaultCompletableObserver
 import com.chaeniiz.weatherdiary.presentation.base.DefaultSingleObserver
 import com.chaeniiz.weatherdiary.presentation.convertWeather
+import usecases.DeleteDiary
 import usecases.GetCurrentWeather
 import usecases.GetDiary
 import usecases.UpdateDiary
@@ -23,7 +24,8 @@ class DiaryPresenter(
             context
         )
     ),
-    private val updateDiary: UpdateDiary = UpdateDiary(DiaryRepository(context))
+    private val updateDiary: UpdateDiary = UpdateDiary(DiaryRepository(context)),
+    private val deleteDiary: DeleteDiary = DeleteDiary(DiaryRepository(context))
 ) {
 
     private var location: String = ""
@@ -48,6 +50,14 @@ class DiaryPresenter(
 
     fun onEditButtonClicked(id: Int, content: String) {
         updateDiary(id, content)
+    }
+
+    fun onDeleteButtonClicked() {
+        view.showDeleteConfirmDialog()
+    }
+
+    fun onDeleteConfirmed(id: Int) {
+        deleteDiary(id)
     }
 
     private fun getDiary(id: Int) {
@@ -100,6 +110,21 @@ class DiaryPresenter(
                 content = content,
                 updatedAt = Date()
             )
+        }.execute(object : DefaultCompletableObserver() {
+            override fun onComplete() {
+                view.finish()
+            }
+
+            override fun onError(e: Throwable) {
+                super.onError(e)
+                view.showErrorToast()
+            }
+        })
+    }
+
+    private fun deleteDiary(id: Int) {
+        deleteDiary.apply {
+            this.id = id
         }.execute(object : DefaultCompletableObserver() {
             override fun onComplete() {
                 view.finish()

--- a/app/src/main/java/com/chaeniiz/weatherdiary/presentation/diary/DiaryPresenter.kt
+++ b/app/src/main/java/com/chaeniiz/weatherdiary/presentation/diary/DiaryPresenter.kt
@@ -6,10 +6,13 @@ import com.chaeniiz.entity.entities.CurrentWeather
 import com.chaeniiz.entity.entities.Diary
 import com.chaeniiz.weatherdiary.data.local.DiaryRepository
 import com.chaeniiz.weatherdiary.data.network.repositories.CurrentWeatherRepository
+import com.chaeniiz.weatherdiary.presentation.base.DefaultCompletableObserver
 import com.chaeniiz.weatherdiary.presentation.base.DefaultSingleObserver
 import com.chaeniiz.weatherdiary.presentation.convertWeather
 import usecases.GetCurrentWeather
 import usecases.GetDiary
+import usecases.UpdateDiary
+import java.util.*
 
 class DiaryPresenter(
     val view: DiaryView,
@@ -19,7 +22,8 @@ class DiaryPresenter(
         CurrentWeatherRepository(
             context
         )
-    )
+    ),
+    private val updateDiary: UpdateDiary = UpdateDiary(DiaryRepository(context))
 ) {
 
     private var location: String = ""
@@ -42,14 +46,20 @@ class DiaryPresenter(
         getCurrentWeather(city)
     }
 
+    fun onEditButtonClicked(id: Int, content: String) {
+        updateDiary(id, content)
+    }
+
     private fun getDiary(id: Int) {
         getDiary.apply {
             this.id = id
         }.execute(object : DefaultSingleObserver<Diary>() {
             override fun onSuccess(t: Diary) {
+                location = t.location
+                weather = t.weather
                 view.setLocationTextView(
-                    location = t.location,
-                    weather = t.weather
+                    location = location,
+                    weather = weather
                 )
                 view.setContentTextView(t.content)
             }
@@ -72,6 +82,27 @@ class DiaryPresenter(
                     weather = t.weather.first().convertWeather()
                 )
                 view.dismissCityDialog()
+            }
+
+            override fun onError(e: Throwable) {
+                super.onError(e)
+                view.showErrorToast()
+            }
+        })
+    }
+
+    private fun updateDiary(id: Int, content: String) {
+        updateDiary.apply {
+            diary = Diary(
+                id = id,
+                location = location,
+                weather = weather,
+                content = content,
+                updatedAt = Date()
+            )
+        }.execute(object : DefaultCompletableObserver() {
+            override fun onComplete() {
+                view.finish()
             }
 
             override fun onError(e: Throwable) {

--- a/app/src/main/java/com/chaeniiz/weatherdiary/presentation/diary/DiaryPresenter.kt
+++ b/app/src/main/java/com/chaeniiz/weatherdiary/presentation/diary/DiaryPresenter.kt
@@ -9,6 +9,7 @@ import com.chaeniiz.weatherdiary.data.network.repositories.CurrentWeatherReposit
 import com.chaeniiz.weatherdiary.presentation.base.DefaultCompletableObserver
 import com.chaeniiz.weatherdiary.presentation.base.DefaultSingleObserver
 import com.chaeniiz.weatherdiary.presentation.convertWeather
+import com.chaeniiz.weatherdiary.presentation.toFormattedString
 import usecases.DeleteDiary
 import usecases.GetCurrentWeather
 import usecases.GetDiary
@@ -74,6 +75,9 @@ class DiaryPresenter(
                 view.setLocationTextView(
                     location = location,
                     weather = weather
+                )
+                view.setUpdatedAtTextView(
+                    t.updatedAt.toFormattedString("yyyy년 M월 dd일 a H시 mm분")
                 )
                 view.setContentTextView(t.content)
             }

--- a/app/src/main/java/com/chaeniiz/weatherdiary/presentation/diary/DiaryPresenter.kt
+++ b/app/src/main/java/com/chaeniiz/weatherdiary/presentation/diary/DiaryPresenter.kt
@@ -49,7 +49,11 @@ class DiaryPresenter(
     }
 
     fun onEditButtonClicked(id: Int, content: String) {
-        updateDiary(id, content)
+        when {
+            location == "" || weather == "" -> view.showErrorDialog(emptyContent = false)
+            content == "" -> view.showErrorDialog(emptyContent = true)
+            else -> updateDiary(id, content)
+        }
     }
 
     fun onDeleteButtonClicked() {

--- a/app/src/main/java/com/chaeniiz/weatherdiary/presentation/diary/DiaryView.kt
+++ b/app/src/main/java/com/chaeniiz/weatherdiary/presentation/diary/DiaryView.kt
@@ -7,5 +7,6 @@ interface DiaryView {
     fun dismissCityDialog()
     fun showErrorToast()
     fun finish()
+    fun showErrorDialog(emptyContent: Boolean)
     fun showDeleteConfirmDialog()
 }

--- a/app/src/main/java/com/chaeniiz/weatherdiary/presentation/diary/DiaryView.kt
+++ b/app/src/main/java/com/chaeniiz/weatherdiary/presentation/diary/DiaryView.kt
@@ -6,4 +6,5 @@ interface DiaryView {
     fun showCityDialog()
     fun dismissCityDialog()
     fun showErrorToast()
+    fun finish()
 }

--- a/app/src/main/java/com/chaeniiz/weatherdiary/presentation/diary/DiaryView.kt
+++ b/app/src/main/java/com/chaeniiz/weatherdiary/presentation/diary/DiaryView.kt
@@ -7,4 +7,5 @@ interface DiaryView {
     fun dismissCityDialog()
     fun showErrorToast()
     fun finish()
+    fun showDeleteConfirmDialog()
 }

--- a/app/src/main/java/com/chaeniiz/weatherdiary/presentation/diary/DiaryView.kt
+++ b/app/src/main/java/com/chaeniiz/weatherdiary/presentation/diary/DiaryView.kt
@@ -1,4 +1,9 @@
 package com.chaeniiz.weatherdiary.presentation.diary
 
 interface DiaryView {
+    fun setLocationTextView(location: String, weather: String)
+    fun setContentTextView(content: String)
+    fun showCityDialog()
+    fun dismissCityDialog()
+    fun showErrorToast()
 }

--- a/app/src/main/java/com/chaeniiz/weatherdiary/presentation/diary/DiaryView.kt
+++ b/app/src/main/java/com/chaeniiz/weatherdiary/presentation/diary/DiaryView.kt
@@ -1,0 +1,4 @@
+package com.chaeniiz.weatherdiary.presentation.diary
+
+interface DiaryView {
+}

--- a/app/src/main/java/com/chaeniiz/weatherdiary/presentation/diary/DiaryView.kt
+++ b/app/src/main/java/com/chaeniiz/weatherdiary/presentation/diary/DiaryView.kt
@@ -2,6 +2,7 @@ package com.chaeniiz.weatherdiary.presentation.diary
 
 interface DiaryView {
     fun setLocationTextView(location: String, weather: String)
+    fun setUpdatedAtTextView(updatedAt: String)
     fun setContentTextView(content: String)
     fun showCityDialog()
     fun dismissCityDialog()

--- a/app/src/main/java/com/chaeniiz/weatherdiary/presentation/home/HomeActivity.kt
+++ b/app/src/main/java/com/chaeniiz/weatherdiary/presentation/home/HomeActivity.kt
@@ -7,10 +7,10 @@ import androidx.recyclerview.widget.LinearLayoutManager
 import com.chaeniiz.entity.entities.Diary
 import com.chaeniiz.weatherdiary.R
 import com.chaeniiz.weatherdiary.presentation.RequestCode
+import com.chaeniiz.weatherdiary.presentation.diary.DiaryActivity
 import com.chaeniiz.weatherdiary.presentation.write.WriteActivity
 import kotlinx.android.synthetic.main.activity_home.*
 import org.jetbrains.anko.onClick
-import org.jetbrains.anko.toast
 
 class HomeActivity : AppCompatActivity(), HomeView {
 
@@ -34,6 +34,13 @@ class HomeActivity : AppCompatActivity(), HomeView {
         presenter.onDestroy()
     }
 
+    override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
+        super.onActivityResult(requestCode, resultCode, data)
+        when (requestCode) {
+            RequestCode.WRITE_ACTIVITY_CODE.ordinal -> presenter.onActivityResultFromWrite()
+        }
+    }
+
     override fun startWriteActivity() {
         WriteActivity.startForResult(this)
     }
@@ -48,14 +55,7 @@ class HomeActivity : AppCompatActivity(), HomeView {
         }
     }
 
-    override fun showToast(text: String) {
-        toast(text)
-    }
-
-    override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
-        super.onActivityResult(requestCode, resultCode, data)
-        when (requestCode) {
-            RequestCode.WRITE_ACTIVITY_CODE.ordinal -> presenter.onActivityResultFromWrite()
-        }
+    override fun showDiary(id: Int) {
+        DiaryActivity.start(this, id)
     }
 }

--- a/app/src/main/java/com/chaeniiz/weatherdiary/presentation/home/HomeActivity.kt
+++ b/app/src/main/java/com/chaeniiz/weatherdiary/presentation/home/HomeActivity.kt
@@ -48,7 +48,7 @@ class HomeActivity : AppCompatActivity(), HomeView {
     override fun setAdapter(diaries: List<Diary>) {
         with(diaryRecyclerView) {
             adapter = HomeRecyclerAdapter(
-                diaries,
+                diaries.asReversed(),
                 presenter::onDiaryClicked
             )
             layoutManager = LinearLayoutManager(context)

--- a/app/src/main/java/com/chaeniiz/weatherdiary/presentation/home/HomeActivity.kt
+++ b/app/src/main/java/com/chaeniiz/weatherdiary/presentation/home/HomeActivity.kt
@@ -37,7 +37,8 @@ class HomeActivity : AppCompatActivity(), HomeView {
     override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
         super.onActivityResult(requestCode, resultCode, data)
         when (requestCode) {
-            RequestCode.WRITE_ACTIVITY_CODE.ordinal -> presenter.onActivityResultFromWrite()
+            RequestCode.WRITE_ACTIVITY_CODE.ordinal,
+            RequestCode.DIARY_ACTIVITY_CODE.ordinal -> presenter.onActivityResult()
         }
     }
 
@@ -48,7 +49,7 @@ class HomeActivity : AppCompatActivity(), HomeView {
     override fun setAdapter(diaries: List<Diary>) {
         with(diaryRecyclerView) {
             adapter = HomeRecyclerAdapter(
-                diaries.asReversed(),
+                diaries.sortedByDescending { it.updatedAt },
                 presenter::onDiaryClicked
             )
             layoutManager = LinearLayoutManager(context)
@@ -56,6 +57,6 @@ class HomeActivity : AppCompatActivity(), HomeView {
     }
 
     override fun showDiary(id: Int) {
-        DiaryActivity.start(this, id)
+        DiaryActivity.startForResult(this, id)
     }
 }

--- a/app/src/main/java/com/chaeniiz/weatherdiary/presentation/home/HomePresenter.kt
+++ b/app/src/main/java/com/chaeniiz/weatherdiary/presentation/home/HomePresenter.kt
@@ -39,7 +39,7 @@ class HomePresenter(
         view.showDiary(id)
     }
 
-    fun onActivityResultFromWrite() {
+    fun onActivityResult() {
         getDiaries()
     }
 }

--- a/app/src/main/java/com/chaeniiz/weatherdiary/presentation/home/HomePresenter.kt
+++ b/app/src/main/java/com/chaeniiz/weatherdiary/presentation/home/HomePresenter.kt
@@ -36,7 +36,7 @@ class HomePresenter(
     }
 
     fun onDiaryClicked(id: Int) {
-        view.showToast("id: $id")
+        view.showDiary(id)
     }
 
     fun onActivityResultFromWrite() {

--- a/app/src/main/java/com/chaeniiz/weatherdiary/presentation/home/HomeRecyclerAdapter.kt
+++ b/app/src/main/java/com/chaeniiz/weatherdiary/presentation/home/HomeRecyclerAdapter.kt
@@ -24,6 +24,6 @@ class HomeRecyclerAdapter(
         }
 
     override fun onBindViewHolder(holder: HomeViewHolder, position: Int) {
-        holder.bind(diaries[position])
+        holder.bind(diaries.asReversed()[position])
     }
 }

--- a/app/src/main/java/com/chaeniiz/weatherdiary/presentation/home/HomeRecyclerAdapter.kt
+++ b/app/src/main/java/com/chaeniiz/weatherdiary/presentation/home/HomeRecyclerAdapter.kt
@@ -24,6 +24,6 @@ class HomeRecyclerAdapter(
         }
 
     override fun onBindViewHolder(holder: HomeViewHolder, position: Int) {
-        holder.bind(diaries.asReversed()[position])
+        holder.bind(diaries[position])
     }
 }

--- a/app/src/main/java/com/chaeniiz/weatherdiary/presentation/home/HomeView.kt
+++ b/app/src/main/java/com/chaeniiz/weatherdiary/presentation/home/HomeView.kt
@@ -5,5 +5,5 @@ import com.chaeniiz.entity.entities.Diary
 interface HomeView {
     fun startWriteActivity()
     fun setAdapter(diaries: List<Diary>)
-    fun showToast(text: String)
+    fun showDiary(id: Int)
 }

--- a/app/src/main/java/com/chaeniiz/weatherdiary/presentation/write/WritePresenter.kt
+++ b/app/src/main/java/com/chaeniiz/weatherdiary/presentation/write/WritePresenter.kt
@@ -8,6 +8,7 @@ import com.chaeniiz.weatherdiary.data.local.DiaryRepository
 import com.chaeniiz.weatherdiary.data.network.repositories.CurrentWeatherRepository
 import com.chaeniiz.weatherdiary.presentation.base.DefaultCompletableObserver
 import com.chaeniiz.weatherdiary.presentation.base.DefaultSingleObserver
+import com.chaeniiz.weatherdiary.presentation.convertWeather
 import usecases.GetCurrentWeather
 import usecases.InsertDiary
 import java.util.*
@@ -52,10 +53,10 @@ class WritePresenter(
             this.city = city.value
         }.execute(object : DefaultSingleObserver<CurrentWeather>() {
             override fun onSuccess(t: CurrentWeather) {
-                weather = convertWeather(t.weather.first().id)
+                weather = t.weather.first().convertWeather()
                 view.setLocationTextView(
                     location = city.formattedString,
-                    weather = convertWeather(t.weather.first().id)
+                    weather = t.weather.first().convertWeather()
                 )
                 view.dismissCityDialog()
             }
@@ -91,15 +92,4 @@ class WritePresenter(
             }
         })
     }
-
-    private fun convertWeather(weatherId: Int): String =
-        when (weatherId) {
-            in 0..299 -> "뇌우"
-            in 300..399 -> "이슬비"
-            in 400..599 -> "비"
-            in 600..699 -> "눈"
-            in 700..799 -> "안개"
-            800 -> "맑음"
-            else -> "구름 많음"
-        }
 }

--- a/app/src/main/res/layout/activity_diary.xml
+++ b/app/src/main/res/layout/activity_diary.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:orientation="vertical" android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+</LinearLayout>

--- a/app/src/main/res/layout/activity_diary.xml
+++ b/app/src/main/res/layout/activity_diary.xml
@@ -15,11 +15,22 @@
         style="@style/Typography.250"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:background="@color/transparent"
         android:gravity="center"
         android:textColor="@drawable/selector_write_text_view"
         app:layout_constraintTop_toTopOf="parent"
         tools:text="서울, 맑음" />
+
+    <TextView
+        android:id="@+id/updatedAtTextView"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        tools:text="2019년 11월 30일 11시 30분"
+        style="@style/Typography.250"
+        android:gravity="center"
+        android:textColor="@color/colorPrimaryDark"
+        app:layout_constraintTop_toBottomOf="@+id/locationTextView"
+        android:layout_marginTop="@dimen/spacing_200"
+        />
 
     <ImageView
         android:id="@+id/startQuotesImageView"
@@ -28,7 +39,7 @@
         android:layout_marginTop="@dimen/spacing_600"
         android:src="@drawable/quotes"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/locationTextView" />
+        app:layout_constraintTop_toBottomOf="@id/updatedAtTextView" />
 
     <EditText
         android:id="@+id/contentEditText"

--- a/app/src/main/res/layout/activity_diary.xml
+++ b/app/src/main/res/layout/activity_diary.xml
@@ -1,6 +1,85 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    android:orientation="vertical" android:layout_width="match_parent"
-    android:layout_height="match_parent">
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:layout_marginStart="@dimen/spacing_500"
+    android:layout_marginTop="@dimen/spacing_675"
+    android:layout_marginEnd="@dimen/spacing_500"
+    android:layout_marginBottom="@dimen/spacing_675"
+    android:orientation="vertical">
 
-</LinearLayout>
+    <TextView
+        android:id="@+id/locationTextView"
+        style="@style/Typography.250"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="@color/transparent"
+        android:gravity="center"
+        android:textColor="@drawable/selector_write_text_view"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:text="서울, 맑음" />
+
+    <ImageView
+        android:id="@+id/startQuotesImageView"
+        android:layout_width="@dimen/quotes_image_size"
+        android:layout_height="@dimen/quotes_image_size"
+        android:layout_marginTop="@dimen/spacing_600"
+        android:src="@drawable/quotes"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/locationTextView" />
+
+    <EditText
+        android:id="@+id/contentEditText"
+        style="@style/Typography.300"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_marginTop="@dimen/spacing_100"
+        android:gravity="start"
+        android:lineSpacingExtra="@dimen/spacing_200"
+        app:layout_constraintBottom_toTopOf="@+id/endQuotesImageView"
+        app:layout_constraintTop_toBottomOf="@+id/startQuotesImageView"
+        tools:text="이따금씩 우리의 하루는 그날의 날씨를 따라가곤 했다." />
+
+    <ImageView
+        android:id="@+id/endQuotesImageView"
+        android:layout_width="@dimen/quotes_image_size"
+        android:layout_height="@dimen/quotes_image_size"
+        android:layout_gravity="end"
+        android:rotation="180"
+        android:src="@drawable/quotes"
+        app:layout_constraintBottom_toTopOf="@+id/editButton"
+        app:layout_constraintEnd_toEndOf="parent" />
+
+    <TextView
+        android:id="@+id/editButton"
+        style="@style/Typography.450"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="bottom"
+        android:gravity="center"
+        android:text="수정"
+        android:textColor="@drawable/selector_write_text_view"
+        android:textStyle="bold"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toStartOf="@+id/deleteButton"
+        app:layout_constraintHorizontal_bias="0.5"
+        app:layout_constraintStart_toStartOf="parent" />
+
+    <TextView
+        android:id="@+id/deleteButton"
+        style="@style/Typography.450"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="bottom"
+        android:gravity="center"
+        android:text="삭제"
+        android:textColor="@drawable/selector_write_text_view"
+        android:textStyle="bold"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="0.5"
+        app:layout_constraintStart_toEndOf="@+id/editButton" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,7 +1,10 @@
 <resources>
     <string name="app_name">Weather Diary</string>
     <string name="general_dialog_accept">확인</string>
+    <string name="general_dialog_cancel">취소</string>
+    <string name="general_dialog_delete">삭제</string>
     <string name="general_error">일시적인 오류가 발생했습니다.</string>
     <string name="error_no_location">위치를 입력해 주세요.</string>
     <string name="error_no_content">내용을 입력해 주세요.</string>
+    <string name="delete_confirm_dialog_message">일기를 삭제할까요?</string>
 </resources>

--- a/domain/src/main/java/com/chaeniiz/domain/repositories/DiaryRepository.kt
+++ b/domain/src/main/java/com/chaeniiz/domain/repositories/DiaryRepository.kt
@@ -9,5 +9,5 @@ interface DiaryRepository {
     fun getDiary(id: Int): Single<Diary>
     fun insertDiary(diary: Diary): Completable
     fun updateDiary(diary: Diary): Completable
-    fun deleteDiary(diary: Diary): Completable
+    fun deleteDiary(id: Int): Completable
 }

--- a/domain/src/main/java/usecases/DeleteDiary.kt
+++ b/domain/src/main/java/usecases/DeleteDiary.kt
@@ -1,0 +1,22 @@
+package usecases
+
+import com.chaeniiz.domain.repositories.DiaryRepository
+import io.reactivex.Completable
+import io.reactivex.Scheduler
+import io.reactivex.android.schedulers.AndroidSchedulers
+import io.reactivex.schedulers.Schedulers
+import usecases.base.CompletableDisposableUseCase
+
+class DeleteDiary(
+    private val repository: DiaryRepository,
+    executorScheduler: Scheduler = Schedulers.io(),
+    postExecutionScheduler: Scheduler = AndroidSchedulers.mainThread()
+) : CompletableDisposableUseCase(executorScheduler, postExecutionScheduler) {
+
+    var id: Int? = null
+
+    override fun buildUseCaseCompletable(): Completable =
+        id?.run {
+            repository.deleteDiary(this)
+        } ?: throw IllegalArgumentException()
+}

--- a/domain/src/main/java/usecases/UpdateDiary.kt
+++ b/domain/src/main/java/usecases/UpdateDiary.kt
@@ -1,0 +1,21 @@
+package usecases
+
+import com.chaeniiz.domain.repositories.DiaryRepository
+import com.chaeniiz.entity.entities.Diary
+import io.reactivex.Completable
+import io.reactivex.Scheduler
+import io.reactivex.android.schedulers.AndroidSchedulers
+import io.reactivex.schedulers.Schedulers
+import usecases.base.CompletableDisposableUseCase
+
+class UpdateDiary(
+    private val repository: DiaryRepository,
+    executorScheduler: Scheduler = Schedulers.io(),
+    postExecutionScheduler: Scheduler = AndroidSchedulers.mainThread()
+) : CompletableDisposableUseCase(executorScheduler, postExecutionScheduler) {
+
+    lateinit var diary: Diary
+
+    override fun buildUseCaseCompletable(): Completable =
+        repository.updateDiary(diary)
+}


### PR DESCRIPTION
일기 수정/조회/삭제 뷰를 만듭니다.
1. 해당 아이디로 수정 / 삭제를 하도록 쿼리를 변경하며, 유즈케이스를 추가합니다.
2. 일기 기록 뷰와 유사한 뷰를 사용하나 `updated_at` 필드에 해당하는 텍스트 뷰가 추가되며, `작성` 버튼의 자리에 `수정` `삭제`가 위치하도록 합니다.
3. 위치 선택 텍스트뷰 클릭 시 일기 기록 뷰와 같이 다이얼로그가 뜨도록 하나, 상단 텍스트를 변경합니다.

기능 | 스크린샷
--- | ---
수정/조회 뷰 | <img width="50%" alt="스크린샷 2019-11-16 오후 8 40 11" src="https://user-images.githubusercontent.com/20873613/68992726-764a4080-08b2-11ea-8dcb-3049a28efb75.png">
위치 선택 다이얼로그 | <img width="50%" alt="스크린샷 2019-11-16 오후 8 48 30" src="https://user-images.githubusercontent.com/20873613/68992725-764a4080-08b2-11ea-9e9f-2ebe7fea6c90.png">

